### PR TITLE
feat: generate personalized starters using Claude

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,16 @@
 ## What does this PR do?
 
-Adds `generateStarters(bio1, bio2)` — a service function that calls the Anthropic Claude API to generate exactly 3 personalised conversation starters for two matched users based on their bios. Validates both bios before calling the API, parses the JSON array response, and asserts the expected length before returning.
+Implements the `GET /api/matches/:id/starters` endpoint which generates personalized conversation starters using the Anthropic Claude API based on the matching users' bios. Results are cached in the PostgreSQL `conversation_starters` table to save API calls on repeated requests. Prompt engineering was extensively refined to improve the casual tone, forcing the AI to only consider the match's bio (Person B) so it doesn't create weird comparisons, and uses an assistant message prefill (`[`) to strictly enforce JSON array output.
 
 ## Related Issue
 
-Closes #17
+Closes #18
 
 ## Type of change
 
 - [x] New feature
 - [ ] Bug fix
-- [ ] Refactor
+- [x] Refactor
 - [ ] DevOps / config
 
 ## Checklist
@@ -21,12 +21,10 @@ Closes #17
 
 ## Code Review Notes
 
-- The model is hardcoded as `claude-sonnet-4-20250514`. Consider moving this to a constant or env var so it can be swapped without touching business logic.
-- `JSON.parse` is called without a try/catch guard. If Claude returns malformed JSON, it will throw an opaque uncaught error. Wrapping just the parse call separately would give a clearer error message.
-- The `!starters` check after `JSON.parse` is a dead branch — `JSON.parse` either returns a value or throws, it never returns `null`/`undefined`. The length check on the next line is the real guard.
-- Error messages like `"something went wrong"` and `"Model error"` are vague — prefer more descriptive strings (e.g. `"Claude returned fewer than 3 starters"`) to make debugging easier.
-- The `Anthropic` client is instantiated at module load time. `ANTHROPIC_API_KEY` must be present in the environment when the module is first imported or the SDK will throw. Consistent with `embedding.ts` but confirm it is set in the Docker environment.
+- Caching logic in `GET /api/matches/:id/starters` normalizes the pair of user IDs so that user A requesting user B returns the same cached result as user B requesting user A (using `pair.sort()`). However, the prompt is one-directional (written to query about Person B's bio). If the cache is reused in reverse, the starters will be referencing User A's interests but presented to User B. This is a logic flaw worth addressing before production.
+- An assistant prefill `[` was added to the prompt messages to enforce the JSON response. Thus, `JSON.parse` is called with `'[' + block.text`. Check to ensure this does not result in malformed JSON if the model ever decides to actually output the `[` on its own.
+- The `anthropic.messages.create` parameters were changed to include `temperature: 0.9`. Ensure that we are satisfied with the response variability.
 
 ## Summary (AI generated)
 
-This branch adds `api/src/services/starters.ts`. The `generateStarters` function validates two bio strings, constructs a prompt instructing Claude to return a JSON array of 3 conversation starters, calls `anthropic.messages.create` with `claude-sonnet-4-20250514`, extracts the text block, parses the JSON, validates the array length, and returns the starters. Errors are logged and re-thrown to the caller.
+This PR introduces the conversation starter generation logic via GET `/api/matches/:id/starters` connecting with the Anthropic Claude API. It includes reading bios for matched users, issuing a well-crafted prompt, caching results in the `conversation_starters` table for subsequent hits on the same user pair, and returning a JSON array of 3 conversation starters. The Anthropic prompt was heavily refactored: removed Person A's bio from the user context to prevent unwanted comparison generation, employed few-shot examples for achieving a natural texting tone, and applied an assistant prefill to robustly enforce a JSON payload response.

--- a/api/src/routes/matches.ts
+++ b/api/src/routes/matches.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance } from "fastify";
 import { UUID } from "node:crypto";
-import { Profile } from "../types/db";
+import { ConversationStarter, Profile } from "../types/db";
+import { generateStarters } from "../services/starters";
 
 export async function matchesRoute(app: FastifyInstance) {
     app.get("/matches", { preHandler: app.authenticate }, async (request, reply) => {
@@ -24,5 +25,48 @@ export async function matchesRoute(app: FastifyInstance) {
 
         return reply.code(200).send({ matches: similarityCheck.rows })
 
+    })
+
+    app.get('/matches/:id/starters', { preHandler: app.authenticate }, async (request, reply) => {
+        const { userId } = request.user as
+            {
+                userId: UUID
+            }
+        const { id: matchId } = request.params as
+            {
+                id: UUID
+            }
+
+        const pair = [userId, matchId]
+        const normalizedPair = pair.sort()
+
+        const existingStarters = await app.db.query<ConversationStarter>(
+            'SELECT starters FROM conversation_starters WHERE user_a_id = $1 AND user_b_id = $2', normalizedPair
+        )
+
+        if (existingStarters.rows.length > 0) {
+            return reply.code(200).send({ starters: existingStarters.rows[0].starters, message: "Successfully Found Starters" })
+        }
+
+        const fetchBios = await app.db.query<Profile>(
+            'SELECT bio FROM profiles WHERE user_id IN ($1,$2)', [userId, matchId]
+        )
+
+        if (fetchBios.rows.length < 2) {
+            return reply.code(404).send({ error: 'Match not found' })
+        }
+
+        const bio1: string = fetchBios.rows[0].bio
+        const bio2: string = fetchBios.rows[1].bio
+
+        const starters: string[] = await generateStarters(bio1, bio2)
+
+        const starterJson: string = JSON.stringify(starters)
+
+        await app.db.query<ConversationStarter>(
+            'INSERT INTO conversation_starters (user_a_id, user_b_id, starters) VALUES ($1,$2,$3)', [normalizedPair[0], normalizedPair[1], starterJson]
+        )
+
+        return reply.code(200).send({ starters, message: "Starters fetched or created successfully" })
     })
 }

--- a/api/src/services/starters.ts
+++ b/api/src/services/starters.ts
@@ -10,21 +10,33 @@ export async function generateStarters(bio1: string, bio2: string): Promise<stri
             throw new Error("Bio is invalid")
         }
 
-        const PROMPT = `You are a matchmaker helping two people start a conversation based on their shared interests.
+        const systemPrompt = [
+            "You write first messages for a matching app. You sound like a real person — curious, casual, a little playful.",
+            "You will receive someone's bio. Write 3 short opening messages TO that person.",
+            "",
+            "Style guide:",
+            "- Talk like you're texting a friend of a friend, not writing a cover letter.",
+            "- Each message: react to ONE thing in their bio + ask ONE question. That's it.",
+            "- Never start with 'I noticed', 'I see that', 'Since we both', 'It's cool that', or 'We both'.",
+            "- Never mention your own interests or hobbies. You're asking about THEIRS.",
+            "- Keep it under 25 words.",
+            "",
+            "Examples of the vibe:",
+            '"Restoring old motorcycles is wild — what\'s the most satisfying part, tearing it apart or putting it back together?"',
+            '"Ok pour over coffee is a whole lifestyle — do you have a go-to bean or are you still experimenting?"',
+            '"Japanese literature rabbit hole, respect. Who got you into it?"',
+        ].join("\n")
 
-        Person A: ${bio1}
-        Person B: ${bio2}
-
-        Generate exactly 3 specific, genuine conversation starters based on their shared interests. Each starter should reference something concrete from both bios.
-
-        Return ONLY a JSON array of 3 strings. No explanation, no preamble, no markdown backticks. Example format:
-        ["starter 1", "starter 2", "starter 3"]`
+        const userMessage = `Here is your match's bio:\n"${bio2}"\n\nWrite 3 opening messages. Return ONLY a JSON array of 3 strings, nothing else.`
 
         const response = await anthropic.messages.create({
             model: 'claude-sonnet-4-20250514',
-            max_tokens: 1024,
+            max_tokens: 512,
+            temperature: 0.9,
+            system: systemPrompt,
             messages: [
-                { role: 'user', content: PROMPT }
+                { role: 'user', content: userMessage },
+                { role: 'assistant', content: '[' }
             ]
         })
 
@@ -34,7 +46,7 @@ export async function generateStarters(bio1: string, bio2: string): Promise<stri
             throw new Error('Unexpected response type from Claude')
         }
 
-        const starters: string[] = JSON.parse(block.text)
+        const starters: string[] = JSON.parse('[' + block.text)
 
         if (!starters) {
             throw new Error("Model error")


### PR DESCRIPTION
## What does this PR do?

Implements the `GET /api/matches/:id/starters` endpoint which generates personalized conversation starters using the Anthropic Claude API based on the matching users' bios. Results are cached in the PostgreSQL `conversation_starters` table to save API calls on repeated requests. Prompt engineering was extensively refined to improve the casual tone, forcing the AI to only consider the match's bio (Person B) so it doesn't create weird comparisons, and uses an assistant message prefill (`[`) to strictly enforce JSON array output.

## Related Issue

Closes #18

## Type of change

- [x] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] DevOps / config

## Checklist

- [x] Code works locally
- [x] No console errors
- [x] Follows existing patterns in the codebase

## Code Review Notes

- Caching logic in `GET /api/matches/:id/starters` normalizes the pair of user IDs so that user A requesting user B returns the same cached result as user B requesting user A (using `pair.sort()`). However, the prompt is one-directional (written to query about Person B's bio). If the cache is reused in reverse, the starters will be referencing User A's interests but presented to User B. This is a logic flaw worth addressing before production.
- An assistant prefill `[` was added to the prompt messages to enforce the JSON response. Thus, `JSON.parse` is called with `'[' + block.text`. Check to ensure this does not result in malformed JSON if the model ever decides to actually output the `[` on its own.
- The `anthropic.messages.create` parameters were changed to include `temperature: 0.9`. Ensure that we are satisfied with the response variability.

## Summary (AI generated)

This PR introduces the conversation starter generation logic via GET `/api/matches/:id/starters` connecting with the Anthropic Claude API. It includes reading bios for matched users, issuing a well-crafted prompt, caching results in the `conversation_starters` table for subsequent hits on the same user pair, and returning a JSON array of 3 conversation starters. The Anthropic prompt was heavily refactored: removed Person A's bio from the user context to prevent unwanted comparison generation, employed few-shot examples for achieving a natural texting tone, and applied an assistant prefill to robustly enforce a JSON payload response.
